### PR TITLE
Add .claude/ to .gitignore and scope changelog check to source

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,14 +73,14 @@ jobs:
             echo "News fragment found."
             exit 0
           fi
-          # Allow skipping for docs-only or CI-only changes
-          changed=$(git diff --name-only origin/main...HEAD)
-          if echo "$changed" | grep -qvE '\.(md|yml|yaml)$'; then
+          # Only require news fragment when source code changes
+          SOURCE_PATHS="^provero-core/src/|^provero-airflow/src/"
+          if git diff --name-only origin/main...HEAD | grep -qE "$SOURCE_PATHS"; then
             echo "::error::Missing news fragment. Add a file to newsfragments/ (e.g. 42.feature.md)"
             echo "See CONTRIBUTING.md for details."
             exit 1
           fi
-          echo "Docs/CI-only change, skipping changelog requirement."
+          echo "No source code changes, skipping changelog requirement."
 
   build-verify:
     runs-on: ubuntu-latest

--- a/newsfragments/1.misc.md
+++ b/newsfragments/1.misc.md
@@ -1,1 +1,0 @@
-Add `.claude/` to `.gitignore` to keep local Claude Code config out of version control.


### PR DESCRIPTION
## Summary

- Add `.claude/` to `.gitignore` to keep local Claude Code config out of version control
- Fix duplicate `.provero/` entry in `.gitignore`
- Scope changelog-check CI job: only require news fragment when `provero-core/src/` or `provero-airflow/src/` are modified. Config, docs, CI, and other non-source changes skip the requirement.

## Test plan

- [ ] Verify changelog-check passes for this PR (no source changes, no fragment needed)
- [ ] Verify changelog-check would still fail for a source-only PR without a fragment