### PR TITLE
fix: update PyPI URLs and add missing project metadata

### DIFF
--- a/provero-airflow/pyproject.toml
+++ b/provero-airflow/pyproject.toml
@@ -24,6 +24,13 @@ dev = [
     "pytest>=8.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/provero-org/provero"
+Repository = "https://github.com/provero-org/provero"
+Issues = "https://github.com/provero-org/provero/issues"
+Documentation = "https://provero.org/docs"
+Changelog = "https://github.com/provero-org/provero/blob/main/CHANGELOG.md"
+
 [build-system]
 requires = ["hatchling>=1.21"]
 build-backend = "hatchling.build"

--- a/provero-core/pyproject.toml
+++ b/provero-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "provero"
-version = "0.0.1"
+version = "0.1.0-dev"
 description = "A vendor-neutral, declarative data quality engine"
 license = "Apache-2.0"
 requires-python = ">=3.11"
@@ -84,6 +84,8 @@ provero = "provero.cli.main:app"
 Homepage = "https://github.com/provero-org/provero"
 Repository = "https://github.com/provero-org/provero"
 Issues = "https://github.com/provero-org/provero/issues"
+Documentation = "https://provero.org/docs"
+Changelog = "https://github.com/provero-org/provero/blob/main/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling>=1.21"]


### PR DESCRIPTION
## Summary

- Updated `provero-core` version from `0.0.1` to `0.1.0-dev`
- Added `Documentation` and `Changelog` URLs to `provero-core/pyproject.toml`
- Added full `[project.urls]` section to `provero-airflow/pyproject.toml`
- Verified no remaining `andreahlert` references exist in the codebase

Closes #7

## Test plan

- [x] Verify `provero-core/pyproject.toml` has correct version and URLs
- [x] Verify `provero-airflow/pyproject.toml` has correct URLs
- [x] Confirm no `andreahlert` references remain in the repo