### PR TITLE
docs: remove references to unimplemented features

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,11 +241,6 @@ provero contract diff old.yaml new.yaml
 | DuckDB      | Stable   | included                         |
 | PostgreSQL  | Stable   | `pip install provero[postgres]`    |
 | DataFrame   | Stable   | `pip install provero[dataframe]`   |
-| MySQL       | Beta     | `pip install provero` (SQLAlchemy) |
-| SQLite      | Beta     | `pip install provero` (SQLAlchemy) |
-| Snowflake   | Beta     | `pip install provero[snowflake]`   |
-| BigQuery    | Beta     | `pip install provero[bigquery]`    |
-| Redshift    | Beta     | `pip install provero[redshift]`    |
 
 DuckDB supports file expressions: `read_csv('data.csv')`, `read_parquet('*.parquet')`.
 

--- a/aql-spec/spec.md
+++ b/aql-spec/spec.md
@@ -67,8 +67,7 @@ suites:
 | `table`     | string | no       | Default table name                   |
 | `conn_id`   | string | no       | Airflow connection ID                |
 
-Supported types: `duckdb`, `postgres`, `postgresql`, `mysql`, `sqlite`,
-`snowflake`, `bigquery`, `redshift`, `databricks`, `dataframe`, `pandas`, `polars`.
+Supported types: `duckdb`, `postgres`, `postgresql`, `dataframe`, `pandas`, `polars`.
 
 ## Check Types
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,6 +6,12 @@ A vendor-neutral, declarative data quality engine with built-in anomaly detectio
 Works standalone, as an Airflow provider, or with any orchestrator.
 Successor espiritual do Apache Griffin, aprendendo com seus erros.
 
+> **Note:** This document describes the target architecture, including planned features
+> not yet implemented. For currently available features, see the [README](../README.md).
+> Unimplemented components include: server mode (FastAPI), streaming engine (Kafka),
+> dedicated cloud connectors (Snowflake, BigQuery, Redshift), email alerts, watch mode,
+> and Prophet-based anomaly detection.
+
 ---
 
 ## Design Principles


### PR DESCRIPTION
## Summary

- Remove MySQL, SQLite, Snowflake, BigQuery, and Redshift from the README connectors table since they have no dedicated connector code or integration tests
- Remove unimplemented connector types from the AQL spec supported types list
- Add a disclaimer to `docs/ARCHITECTURE.md` clarifying it describes the target architecture, not current functionality

Connectors table now only lists DuckDB, PostgreSQL, and DataFrame (all Stable). Optional dependencies in `pyproject.toml` are kept as-is for future development.

Closes #8

## Test plan

- [ ] Verify README connectors table only shows DuckDB, PostgreSQL, DataFrame
- [ ] Verify AQL spec supported types match implemented connectors
- [ ] Verify ARCHITECTURE.md disclaimer is visible and accurate