### PR TITLE
Add MkDocs Material documentation site

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,42 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mkdocs-material
+      - run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,8 @@ Thumbs.db
 # Claude Code (local config)
 .claude/
 
+# Docs
+site/
+
 # Data directories
 .provero/

--- a/README.md
+++ b/README.md
@@ -293,13 +293,18 @@ check_orders = ProveroCheckOperator(
 
 ## Documentation
 
-- [AQL Specification](aql-spec/spec.md)
+**[Full documentation](https://provero-org.github.io/provero/)** is available on GitHub Pages.
+
+- [Getting Started](https://provero-org.github.io/provero/getting-started/)
+- [Configuration](https://provero-org.github.io/provero/configuration/)
+- [Check Types](https://provero-org.github.io/provero/checks/)
+- [Connectors](https://provero-org.github.io/provero/connectors/)
+- [CLI Reference](https://provero-org.github.io/provero/cli/)
 - [Architecture](docs/ARCHITECTURE.md)
 - [Contributing](CONTRIBUTING.md)
 - [Governance](GOVERNANCE.md)
 - [Security Policy](SECURITY.md)
 - [Support](SUPPORT.md)
-- [Development Plan](DEVELOPMENT_PLAN.md)
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ Works standalone, as an Airflow provider, or with any orchestrator.
 Successor espiritual do Apache Griffin, aprendendo com seus erros.
 
 > **Note:** This document describes the target architecture, including planned features
-> not yet implemented. For currently available features, see the [README](../README.md).
+> not yet implemented. For currently available features, see the [README](https://github.com/provero-org/provero/blob/main/README.md).
 > Unimplemented components include: server mode (FastAPI), streaming engine (Kafka),
 > dedicated cloud connectors (Snowflake, BigQuery, Redshift), email alerts, watch mode,
 > and Prophet-based anomaly detection.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -59,7 +59,7 @@ Each release branch has constraint files in `constraints/` that pin exact depend
 
 ## News Fragments
 
-Every PR must include a news fragment in `newsfragments/`. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.
+Every PR must include a news fragment in `newsfragments/`. See [CONTRIBUTING.md](https://github.com/provero-org/provero/blob/main/CONTRIBUTING.md) for details.
 
 ## PyPI Publishing
 

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -1,0 +1,305 @@
+# Check Types
+
+Provero includes 14 built-in check types organized by category. Each check can be written in shorthand or expanded YAML form.
+
+## Completeness
+
+### not_null
+
+Verifies that column(s) contain no null values.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| column(s) | string or list | Yes | Column name or list of column names |
+
+Default severity: `critical`
+
+=== "Shorthand"
+
+    ```yaml
+    checks:
+      - not_null: order_id
+      - not_null: [order_id, customer_id, amount]
+    ```
+
+=== "Expanded"
+
+    ```yaml
+    checks:
+      - not_null: order_id
+        severity: warning
+    ```
+
+### completeness
+
+Checks that a column meets a minimum percentage of non-null values.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `column` | string | Yes | | Column to check |
+| `min` | number | No | `0.95` | Minimum completeness ratio (0 to 1) |
+
+Default severity: `critical`
+
+```yaml
+checks:
+  - completeness:
+      column: email
+      min: 0.90
+```
+
+## Uniqueness
+
+### unique
+
+Verifies that a column has no duplicate values.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| column | string | Yes | Column name |
+
+Default severity: `critical`
+
+```yaml
+checks:
+  - unique: order_id
+```
+
+### unique_combination
+
+Checks that a combination of columns is unique (composite key).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| columns | list | Yes | List of column names (minimum 2) |
+
+Default severity: `critical`
+
+```yaml
+checks:
+  - unique_combination: [date, store_id]
+```
+
+## Validity
+
+### accepted_values
+
+Ensures column values are within an allowed set.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `column` | string | Yes | Column to check |
+| `values` | list | Yes | Allowed values (strings, numbers, or booleans) |
+
+Default severity: `critical`
+
+```yaml
+checks:
+  - accepted_values:
+      column: status
+      values: [pending, shipped, delivered, cancelled]
+```
+
+### range
+
+Verifies that numeric values fall within min/max bounds.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `column` | string | Yes | Column to check |
+| `min` | number | No | Minimum allowed value |
+| `max` | number | No | Maximum allowed value |
+
+At least one of `min` or `max` should be specified.
+
+Default severity: `critical`
+
+```yaml
+checks:
+  - range:
+      column: amount
+      min: 0
+      max: 100000
+```
+
+### regex
+
+Validates that column values match a regular expression pattern.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `column` | string | Yes | Column to check |
+| `pattern` | string | Yes | Regular expression pattern |
+
+Works across databases: uses `regexp_matches()` on DuckDB, `~` on PostgreSQL, and `REGEXP` on MySQL/SQLite.
+
+Default severity: `warning`
+
+```yaml
+checks:
+  - regex:
+      column: email
+      pattern: "^[^@]+@[^@]+\\.[^@]+$"
+```
+
+### type
+
+Checks that a column's data type matches the expected type.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `column` | string | Yes | Column to check |
+| `expected` | string | Yes | Expected type: `integer`, `float`, `string`, `boolean`, `date`, `timestamp` |
+
+Type names are normalized across databases. For example, `int`, `int4`, `bigint`, and `smallint` all match `integer`.
+
+Default severity: `critical`
+
+```yaml
+checks:
+  - type:
+      column: amount
+      expected: float
+```
+
+## Freshness
+
+### freshness
+
+Checks that the most recent row is within a time threshold.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `column` | string | Yes | | Timestamp column |
+| `max_age` | string | Yes | `24h` | Maximum age. Format: `30m`, `24h`, `7d` |
+
+Default severity: `critical`
+
+```yaml
+checks:
+  - freshness:
+      column: updated_at
+      max_age: 24h
+```
+
+### latency
+
+Measures the time difference between two timestamp columns. Useful for detecting pipeline delays.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `source_column` | string | Yes | | Start timestamp (e.g., event time) |
+| `target_column` | string | Yes | | End timestamp (e.g., load time) |
+| `max_latency` | string | No | `1h` | Maximum acceptable latency |
+
+Default severity: `warning`
+
+```yaml
+checks:
+  - latency:
+      source_column: created_at
+      target_column: processed_at
+      max_latency: 1h
+```
+
+## Volume
+
+### row_count
+
+Validates that the table row count is within expected bounds.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `min` | integer | No | `0` | Minimum row count |
+| `max` | integer | No | | Maximum row count |
+
+Default severity: `critical`
+
+```yaml
+checks:
+  - row_count:
+      min: 1
+      max: 1000000
+```
+
+### row_count_change
+
+Compares the current row count against the previous run. Requires the result store to be enabled (default).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `max_decrease` | string | No | `50%` | Maximum allowed decrease percentage |
+| `max_increase` | string | No | `500%` | Maximum allowed increase percentage |
+
+Default severity: `warning`
+
+```yaml
+checks:
+  - row_count_change:
+      max_decrease: "10%"
+      max_increase: "200%"
+```
+
+## Anomaly Detection
+
+### anomaly
+
+Statistical anomaly detection on historical metrics. Compares the current value against stored history using one of three methods.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `metric` | string | Yes | | Metric to check: `row_count`, `null_count`, `null_rate`, `distinct_count`, `mean`, `min`, `max` |
+| `column` | string | No | | Column for column-level metrics |
+| `method` | string | No | `mad` | Detection method: `zscore`, `mad`, `iqr` |
+| `sensitivity` | string | No | `medium` | Sensitivity level |
+| `threshold` | float | No | | Direct threshold override |
+
+Default severity: `warning`
+
+```yaml
+checks:
+  - anomaly:
+      column: daily_revenue
+      metric: mean
+      method: mad
+      sensitivity: medium
+```
+
+**Detection methods:**
+
+| Method | Description | Best for |
+|--------|-------------|----------|
+| `zscore` | Standard Z-Score | Normally distributed metrics |
+| `mad` | Median Absolute Deviation | Robust to outliers |
+| `iqr` | Interquartile Range | Skewed distributions |
+
+All methods are implemented using Python stdlib only (no scipy dependency). Anomaly detection uses the result store to compare current values against historical data. Run `provero run` regularly to build up the baseline.
+
+## Custom
+
+### custom_sql
+
+Runs a custom SQL query that must return a truthy value to pass.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | SQL query returning a single value |
+| `name` | string | No | Custom name for the check |
+
+Default severity: `critical`
+
+=== "Shorthand"
+
+    ```yaml
+    checks:
+      - custom_sql: "SELECT COUNT(*) > 0 FROM orders"
+    ```
+
+=== "Expanded"
+
+    ```yaml
+    checks:
+      - custom_sql:
+          name: positive_revenue
+          query: "SELECT SUM(amount) > 0 FROM orders"
+    ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,175 @@
+# CLI Reference
+
+## provero init
+
+Create a new `provero.yaml` template.
+
+```bash
+provero init [PATH] [--from-source TYPE:TABLE]
+```
+
+| Argument / Flag | Default | Description |
+|-----------------|---------|-------------|
+| `PATH` | `provero.yaml` | Path for the config file |
+| `--from-source` | | Generate checks by profiling a table. Format: `TYPE:TABLE` (e.g., `duckdb:orders`) |
+
+**Examples:**
+
+```bash
+provero init
+provero init my_checks.yaml
+provero init --from-source duckdb:orders
+provero init --from-source postgres:users
+```
+
+## provero run
+
+Execute quality checks defined in the config file.
+
+```bash
+provero run [OPTIONS]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--config` | `-c` | `provero.yaml` | Config file path |
+| `--suite` | `-s` | | Run a specific suite only |
+| `--tag` | `-t` | | Run suites matching this tag |
+| `--format` | `-f` | `table` | Output format: `table`, `json` |
+| `--no-store` | | `false` | Don't persist results to SQLite |
+| `--no-optimize` | | `false` | Disable SQL batching |
+| `--no-alerts` | | `false` | Don't send webhook alerts |
+| `--report` | | | Generate a report: `html` |
+
+**Examples:**
+
+```bash
+provero run
+provero run -c production.yaml
+provero run --suite orders_quality
+provero run --tag critical
+provero run --format json
+provero run --report html
+provero run --no-store --no-alerts
+```
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| 0 | All checks passed (or only info/warning failures) |
+| 1 | At least one critical/blocker check failed |
+
+## provero validate
+
+Validate config syntax without running checks.
+
+```bash
+provero validate [OPTIONS]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--config` | `-c` | `provero.yaml` | Config file path |
+| `--schema-only` | | `false` | Only validate against JSON Schema (skip semantic checks) |
+
+**Examples:**
+
+```bash
+provero validate
+provero validate -c production.yaml
+provero validate --schema-only
+```
+
+## provero profile
+
+Profile a data source and optionally suggest checks.
+
+```bash
+provero profile [OPTIONS]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--config` | `-c` | `provero.yaml` | Config file path |
+| `--table` | `-t` | | Table to profile (overrides config) |
+| `--suggest` | | `false` | Suggest checks based on the profile |
+| `--sample` | | | Sample size for large tables |
+
+**Examples:**
+
+```bash
+provero profile
+provero profile --table orders
+provero profile --suggest
+provero profile --table orders --suggest --sample 10000
+```
+
+## provero history
+
+Show historical check results from the result store.
+
+```bash
+provero history [OPTIONS]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--suite` | `-s` | | Filter by suite name |
+| `--limit` | `-n` | `20` | Number of runs to show |
+| `--run` | `-r` | | Show details for a specific run ID |
+
+**Examples:**
+
+```bash
+provero history
+provero history --suite orders_quality
+provero history -n 50
+provero history --run abc12345
+```
+
+## provero contract validate
+
+Validate data contracts against live data sources.
+
+```bash
+provero contract validate [OPTIONS]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--config` | `-c` | `provero.yaml` | Config file path |
+
+**Examples:**
+
+```bash
+provero contract validate
+provero contract validate -c production.yaml
+```
+
+## provero contract diff
+
+Show differences between two contract versions. Reports added/removed/changed columns, type changes, and whether changes are breaking.
+
+```bash
+provero contract diff OLD_CONFIG NEW_CONFIG
+```
+
+| Argument | Description |
+|----------|-------------|
+| `OLD_CONFIG` | Path to the old config file |
+| `NEW_CONFIG` | Path to the new config file |
+
+**Example:**
+
+```bash
+provero contract diff v1.yaml v2.yaml
+```
+
+## provero version
+
+Show the installed Provero version.
+
+```bash
+provero version
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,200 @@
+# Configuration
+
+Provero uses a `provero.yaml` file to define data sources, quality checks, alerts, and contracts. There are two formats: **simple** (single source) and **full** (multiple suites).
+
+## Simple Format
+
+Best for single-table validation:
+
+```yaml
+source:
+  type: duckdb
+  table: orders
+
+checks:
+  - not_null: [order_id, customer_id]
+  - unique: order_id
+  - row_count:
+      min: 1
+```
+
+## Full Format
+
+For multi-table pipelines with named sources and suites:
+
+```yaml
+version: "1.0"
+
+sources:
+  warehouse:
+    type: duckdb
+    # type: postgres
+    # connection: ${WAREHOUSE_URI}
+
+suites:
+  - name: orders_quality
+    source: warehouse
+    table: orders
+    tags: [critical, daily]
+    checks:
+      - not_null: [order_id, customer_id, order_date, total_amount]
+      - unique: order_id
+      - row_count:
+          min: 1
+      - range:
+          column: total_amount
+          min: 0
+          max: 100000
+      - freshness:
+          column: order_date
+          max_age: 24h
+
+  - name: customers_quality
+    source: warehouse
+    table: customers
+    tags: [critical, daily]
+    checks:
+      - not_null: [customer_id, email, created_at]
+      - unique: customer_id
+      - unique: email
+      - regex:
+          column: email
+          pattern: "^[^@]+@[^@]+\\.[^@]+$"
+```
+
+## Source Configuration
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | **Required.** Connector type: `duckdb`, `postgres`, `dataframe` |
+| `table` | string | Table name or DuckDB expression (e.g., `read_csv('file.csv')`) |
+| `connection` | string | Connection string for databases. Supports `${ENV_VAR}` |
+| `conn_id` | string | Airflow connection ID (for Airflow provider) |
+
+## Severity Levels
+
+Each check has a severity level that determines behavior on failure:
+
+| Level | Exit Code | Description |
+|-------|-----------|-------------|
+| `info` | 0 | Informational, does not affect exit code |
+| `warning` | 0 | Warning, logged but does not affect exit code |
+| `critical` | 1 | Failure causes non-zero exit code (default for most checks) |
+| `blocker` | 1 | Same as critical, indicates a blocking issue |
+
+Override severity per check:
+
+```yaml
+checks:
+  - range:
+      column: price
+      min: 0
+      severity: warning
+  - completeness:
+      column: description
+      min: 0.80
+      severity: warning
+```
+
+## Alerts
+
+Send webhook notifications when checks fail:
+
+```yaml
+alerts:
+  - type: webhook
+    url: https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+    trigger: on_failure
+  - type: webhook
+    url: ${PAGERDUTY_WEBHOOK}
+    headers:
+      Authorization: "Bearer ${PD_TOKEN}"
+    trigger: always
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | string | `webhook` | Alert type (currently only `webhook`) |
+| `url` | string | | **Required.** Webhook URL. Supports `${ENV_VAR}` |
+| `trigger` | string | `on_failure` | When to fire: `on_failure`, `on_success`, `always` |
+| `headers` | object | | HTTP headers. Values support `${ENV_VAR}` |
+
+## Data Contracts
+
+Define and enforce schema contracts on your data:
+
+```yaml
+contracts:
+  - name: orders_contract
+    owner: data-team
+    table: orders
+    on_violation: warn
+    schema:
+      columns:
+        - name: order_id
+          type: integer
+          checks: [not_null, unique]
+        - name: status
+          type: varchar
+    sla:
+      freshness: 24h
+      completeness: "95%"
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | **Required.** Contract identifier |
+| `owner` | string | Team or person responsible |
+| `table` | string | Table the contract applies to |
+| `source` | string/object | Named source reference or inline source config |
+| `on_violation` | string | Action on violation: `block`, `warn`, `quarantine` |
+| `schema.columns` | array | Column definitions with `name`, `type`, and optional `checks` |
+| `sla.freshness` | string | Maximum data age (e.g., `24h`) |
+| `sla.completeness` | string | Minimum completeness percentage (e.g., `"95%"`) |
+
+Validate contracts against live data:
+
+```bash
+provero contract validate
+```
+
+Compare two contract versions:
+
+```bash
+provero contract diff old.yaml new.yaml
+```
+
+## Environment Variables
+
+Use `${VAR_NAME}` syntax anywhere in the config to reference environment variables:
+
+```yaml
+source:
+  type: postgres
+  connection: ${DATABASE_URL}
+
+alerts:
+  - type: webhook
+    url: ${SLACK_WEBHOOK}
+    headers:
+      Authorization: "Bearer ${SLACK_TOKEN}"
+```
+
+## JSON Schema
+
+Provero ships a JSON Schema for `provero.yaml`. Enable IDE autocomplete by adding a schema reference:
+
+```yaml
+# yaml-language-server: $schema=https://github.com/provero-org/provero/raw/main/aql-spec/schema.json
+source:
+  type: duckdb
+  table: orders
+checks:
+  - not_null: order_id
+```
+
+Validate your config against the schema without running checks:
+
+```bash
+provero validate --schema-only
+```

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -1,0 +1,142 @@
+# Connectors
+
+| Connector | Status | Install |
+|-----------|--------|---------|
+| DuckDB | Stable | included |
+| PostgreSQL | Stable | `pip install provero[postgres]` |
+| DataFrame | Stable | `pip install provero[dataframe]` |
+
+## DuckDB
+
+DuckDB is the default connector and ships with Provero. It supports both in-memory databases and file-based databases, and can read CSV, Parquet, and JSON files directly.
+
+### Basic Usage
+
+```yaml
+source:
+  type: duckdb
+  table: orders
+```
+
+### File Expressions
+
+DuckDB supports file expressions as the `table` value, letting you query files directly without loading them into a database:
+
+```yaml
+source:
+  type: duckdb
+  table: read_csv('data/orders.csv')
+```
+
+```yaml
+source:
+  type: duckdb
+  table: read_parquet('data/*.parquet')
+```
+
+```yaml
+source:
+  type: duckdb
+  table: read_json('events.json')
+```
+
+### File-based Database
+
+To use a persistent DuckDB file instead of in-memory:
+
+```yaml
+source:
+  type: duckdb
+  connection: warehouse.duckdb
+  table: orders
+```
+
+## PostgreSQL
+
+Requires the `postgres` extra: `pip install provero[postgres]`.
+
+Uses SQLAlchemy under the hood, so any PostgreSQL-compatible connection string works.
+
+### Connection String
+
+```yaml
+source:
+  type: postgres
+  connection: postgresql://user:password@localhost:5432/mydb
+  table: orders
+```
+
+Use environment variables to avoid hardcoding credentials:
+
+```yaml
+source:
+  type: postgres
+  connection: ${DATABASE_URL}
+  table: orders
+```
+
+### Schema-qualified Tables
+
+Use dot notation to specify a schema:
+
+```yaml
+source:
+  type: postgres
+  connection: ${DATABASE_URL}
+  table: analytics.orders
+```
+
+## DataFrame
+
+Requires the `dataframe` extra: `pip install provero[dataframe]`.
+
+The DataFrame connector is designed for programmatic use from Python, not from YAML configs. It registers a Pandas or Polars DataFrame as a virtual table in an in-memory DuckDB instance, allowing full SQL execution against it.
+
+### Pandas
+
+```python
+import pandas as pd
+from provero.connectors.dataframe import DataFrameConnector
+from provero.core.engine import Engine
+
+df = pd.read_csv("orders.csv")
+
+engine = Engine.from_dict(
+    config={
+        "source": {"type": "dataframe", "table": "orders"},
+        "checks": [
+            {"not_null": "order_id"},
+            {"unique": "order_id"},
+            {"row_count": {"min": 1}},
+        ],
+    },
+    dataframe=df,
+    table_name="orders",
+)
+results = engine.run()
+```
+
+### Polars
+
+Polars DataFrames are converted to Arrow tables and registered in DuckDB transparently:
+
+```python
+import polars as pl
+from provero.connectors.dataframe import DataFrameConnector
+from provero.core.engine import Engine
+
+df = pl.read_csv("orders.csv")
+
+engine = Engine.from_dict(
+    config={
+        "source": {"type": "dataframe", "table": "orders"},
+        "checks": [
+            {"not_null": "order_id"},
+            {"row_count": {"min": 1}},
+        ],
+    },
+    dataframe=df,
+    table_name="orders",
+)
+results = engine.run()
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,105 @@
+# Getting Started
+
+## Installation
+
+```bash
+pip install provero
+```
+
+For additional connectors, install with extras:
+
+| Extra | Install | Provides |
+|-------|---------|----------|
+| `postgres` | `pip install provero[postgres]` | PostgreSQL via SQLAlchemy |
+| `dataframe` | `pip install provero[dataframe]` | Pandas/Polars DataFrame support |
+
+## Initialize a Project
+
+```bash
+provero init
+```
+
+This creates a `provero.yaml` template in the current directory:
+
+```yaml
+# provero.yaml - Provero configuration
+# Docs: https://provero.apache.org/docs
+
+source:
+  type: duckdb
+  # type: postgres
+  # connection: ${POSTGRES_URI}
+  table: my_table
+
+checks:
+  - not_null: [id, name]
+  - unique: id
+  - row_count:
+      min: 1
+```
+
+You can also generate checks automatically by profiling a live data source:
+
+```bash
+provero init --from-source duckdb:orders
+```
+
+## Write Your First Config
+
+Edit `provero.yaml` to point at your data. Here is a complete example using a CSV file with DuckDB:
+
+```yaml
+source:
+  type: duckdb
+  table: read_csv('examples/quickstart/orders.csv')
+
+checks:
+  - not_null: [order_id, customer_id, amount]
+  - unique: order_id
+  - accepted_values:
+      column: status
+      values: [pending, shipped, delivered, cancelled]
+  - range:
+      column: amount
+      min: 0
+      max: 100000
+  - row_count:
+      min: 1
+```
+
+## Run Checks
+
+```bash
+provero run
+```
+
+Provero compiles your checks into optimized SQL, executes them, and displays a results table with pass/fail status, observed vs expected values, and a quality score.
+
+Common flags:
+
+| Flag | Description |
+|------|-------------|
+| `--config`, `-c` | Config file path (default: `provero.yaml`) |
+| `--format`, `-f` | Output format: `table` or `json` |
+| `--suite`, `-s` | Run a specific suite |
+| `--tag`, `-t` | Run suites with a specific tag |
+| `--report html` | Generate an HTML report |
+| `--no-store` | Don't persist results to SQLite |
+| `--no-alerts` | Don't send webhook alerts |
+
+## Validate Config
+
+Check your configuration syntax without running any checks:
+
+```bash
+provero validate
+```
+
+This validates against the JSON Schema and compiles the config to verify semantic correctness.
+
+## Next Steps
+
+- [Configuration](configuration.md) for the full config reference (simple vs full format, alerts, contracts)
+- [Check Types](checks.md) for all 14 check types with parameters and examples
+- [Connectors](connectors.md) for PostgreSQL and DataFrame setup
+- [CLI Reference](cli.md) for all commands and flags

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,79 @@
+# Provero
+
+> **provero** (Esperanto): to test, to put to proof.
+
+A vendor-neutral, declarative data quality engine.
+
+<p align="center">
+  <img src="assets/demo.gif" alt="Provero demo" width="700">
+</p>
+
+## Why Provero?
+
+- **14 check types** covering completeness, uniqueness, validity, freshness, volume, anomaly detection, and custom SQL
+- **3 connectors**: DuckDB (files + in-memory), PostgreSQL, Pandas/Polars DataFrame
+- **SQL batch optimizer** compiles N checks into 1 query
+- **Data contracts** with schema validation, SLA enforcement, and contract diff
+- **Anomaly detection** using Z-Score, MAD, IQR (stdlib only, no scipy needed)
+- **HTML reports** via `provero run --report html`
+- **Webhook alerts** for Slack, PagerDuty, or any HTTP endpoint
+- **Result store** with SQLite time-series metrics and `provero history`
+- **Data profiling** with `provero profile --suggest` to auto-generate checks
+- **Configurable severity**: info, warning, critical, blocker per check
+- **JSON Schema validation** for `provero.yaml`
+- **Airflow provider**: `ProveroCheckOperator` + `@provero_check` decorator
+
+## Quick Install
+
+```bash
+pip install provero
+```
+
+## Minimal Example
+
+```yaml
+source:
+  type: duckdb
+  table: orders
+
+checks:
+  - not_null: [order_id, customer_id, amount]
+  - unique: order_id
+  - accepted_values:
+      column: status
+      values: [pending, shipped, delivered, cancelled]
+  - range:
+      column: amount
+      min: 0
+      max: 100000
+  - row_count:
+      min: 1
+```
+
+```bash
+provero run
+```
+
+```
+┌─────────────────┬──────────────┬──────────┬──────────────────┬──────────────────┐
+│ Check           │ Column       │ Status   │ Observed         │ Expected         │
+├─────────────────┼──────────────┼──────────┼──────────────────┼──────────────────┤
+│ not_null        │ order_id     │ ✓ PASS   │ 0 nulls          │ 0 nulls          │
+│ not_null        │ customer_id  │ ✓ PASS   │ 0 nulls          │ 0 nulls          │
+│ not_null        │ amount       │ ✓ PASS   │ 0 nulls          │ 0 nulls          │
+│ unique          │ order_id     │ ✓ PASS   │ 0 duplicates     │ 0 duplicates     │
+│ accepted_values │ status       │ ✓ PASS   │ 0 invalid values │ only [pending..] │
+│ range           │ amount       │ ✓ PASS   │ min=45, max=999  │ min=0, max=100k  │
+│ row_count       │ -            │ ✓ PASS   │ 5                │ >= 1             │
+└─────────────────┴──────────────┴──────────┴──────────────────┴──────────────────┘
+
+Score: 100/100 | 7 passed, 0 failed | 22ms
+```
+
+## Next Steps
+
+- [Getting Started](getting-started.md) for a full walkthrough
+- [Configuration](configuration.md) for all config options
+- [Check Types](checks.md) for the complete check reference
+- [Connectors](connectors.md) for database setup
+- [CLI Reference](cli.md) for all commands and flags

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,13 @@
+/* Provero docs - minimal overrides */
+
+.md-header {
+  --md-primary-fg-color: #3f51b5;
+}
+
+.md-typeset h1 {
+  font-weight: 700;
+}
+
+.md-typeset table:not([class]) th {
+  background-color: var(--md-default-fg-color--lightest);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,62 @@
+site_name: Provero
+site_url: https://provero-org.github.io/provero/
+site_description: Vendor-neutral, declarative data quality engine.
+repo_url: https://github.com/provero-org/provero
+repo_name: provero-org/provero
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - content.code.copy
+    - content.code.annotate
+    - navigation.instant
+    - navigation.tracking
+    - search.highlight
+    - search.suggest
+    - toc.follow
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.snippets
+  - tables
+  - toc:
+      permalink: true
+  - attr_list
+  - md_in_html
+
+extra_css:
+  - stylesheets/extra.css
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Configuration: configuration.md
+  - Check Types: checks.md
+  - Connectors: connectors.md
+  - CLI Reference: cli.md
+  - Architecture: ARCHITECTURE.md
+  - Release Process: RELEASE_PROCESS.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ dev = [
     "types-jsonschema>=4.20",
     "towncrier>=24.7",
 ]
+docs = [
+    "mkdocs-material>=9.5",
+]
 
 [tool.towncrier]
 directory = "newsfragments"

--- a/uv.lock
+++ b/uv.lock
@@ -310,6 +310,9 @@ dev = [
     { name = "types-jsonschema" },
     { name = "types-pyyaml" },
 ]
+docs = [
+    { name = "mkdocs-material" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -331,6 +334,7 @@ dev = [
     { name = "types-jsonschema", specifier = ">=4.20" },
     { name = "types-pyyaml", specifier = ">=6.0" },
 ]
+docs = [{ name = "mkdocs-material", specifier = ">=9.5" }]
 
 [[package]]
 name = "argcomplete"
@@ -375,6 +379,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/e325ec73b638d3ede4421b5445d4a0b8b219481826cc079d510100af356c/backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49", size = 7012303, upload-time = "2026-02-16T19:10:15.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/39/3765df263e08a4df37f4f43cb5aa3c6c17a4bdd42ecfe841e04c26037171/backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8", size = 381075, upload-time = "2026-02-16T19:10:04.322Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/f0/35240571e1b67ffb19dafb29ab34150b6f59f93f717b041082cdb1bfceb1/backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be", size = 392874, upload-time = "2026-02-16T19:10:06.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/77e8c9745b4d227cce9f5e0a6f68041278c5f9b18588b35905f5f19c1beb/backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90", size = 398787, upload-time = "2026-02-16T19:10:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
 ]
 
 [[package]]
@@ -1147,6 +1165,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
 ]
 
 [[package]]
@@ -1973,6 +2003,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2132,6 +2171,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
 name = "methodtools"
 version = "0.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -2141,6 +2189,75 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/13/3b/c21b74ac17befdf17b286494b02221b7a84affb1d410ff86e38ba0e14b13/methodtools-0.4.7.tar.gz", hash = "sha256:e213439dd64cfe60213f7015da6efe5dd4003fd89376db3baa09fe13ec2bb0ba", size = 3586, upload-time = "2023-02-05T13:17:54.473Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/4b/6497ffb463b1b75e04b348ef31070606d43e3c503fa295383538ded999c9/methodtools-0.4.7-py2.py3-none-any.whl", hash = "sha256:5e188c780b236adc12e75b5f078c5afb419ef99eb648569fc6d7071f053a1f11", size = 4038, upload-time = "2024-08-23T09:18:03.631Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/76/5c202fecdc45d53e83e03a85bae70c48b6c81e9f87f0bc19a9e9c723bdc0/mkdocs_material-9.7.5.tar.gz", hash = "sha256:f76bdab532bad1d9c57ca7187b37eccf64dd12e1586909307f8856db3be384ea", size = 4097749, upload-time = "2026-03-10T15:43:22.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/e1/e8080dcfa95cca267662a6f4afe29237452bdeb5a2a6555ac83646d21915/mkdocs_material-9.7.5-py3-none-any.whl", hash = "sha256:7cf9df2ff121fd098ff6e05c732b0be3699afca9642e2dfe4926c40eb5873eec", size = 9305251, upload-time = "2026-03-10T15:43:19.089Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
 ]
 
 [[package]]
@@ -2480,6 +2597,15 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pandas"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2808,7 +2934,7 @@ wheels = [
 
 [[package]]
 name = "provero"
-version = "0.0.1"
+version = "0.1.0.dev0"
 source = { editable = "provero-core" }
 dependencies = [
     { name = "duckdb" },
@@ -3196,6 +3322,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
+]
+
+[[package]]
 name = "pyopenssl"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3389,6 +3528,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]
@@ -4367,6 +4518,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Set up MkDocs Material with light/dark toggle, search, code copy, and GitHub Pages deploy workflow
- Add 6 documentation pages: Getting Started, Configuration, Check Types (14 checks), Connectors, CLI Reference, and landing page
- Fix broken links in existing `ARCHITECTURE.md` and `RELEASE_PROCESS.md` for MkDocs compatibility
- Update README with docs site links

## Test plan

- [x] `uv sync --group docs` installs successfully
- [x] `uv run mkdocs build --strict` passes with zero warnings
- [x] `uv run mkdocs serve` renders all pages correctly at localhost:8000
- [ ] Light/dark mode toggle works
- [ ] All internal links resolve
- [ ] Code blocks render with syntax highlighting
- [ ] Tabbed content (Simple/Expanded) works on checks page

Closes #9, #11, #12, #13, #14, #15