### PR TITLE
Update Slack link to public invite URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,4 +137,4 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 
 - [GitHub Discussions](https://github.com/provero-org/provero/discussions) for questions and ideas
 - [GitHub Issues](https://github.com/provero-org/provero/issues) for bug reports and feature requests
-- [Slack](https://provero.slack.com) for real-time chat
+- [Slack](https://join.slack.com/t/provero/shared_invite/zt-3sj71s3ic-ey5Gf~Ls_YcmdMKkDz9oAQ) for real-time chat

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,7 +4,7 @@
 
 - **Questions and ideas**: [GitHub Discussions](https://github.com/provero-org/provero/discussions)
 - **Bug reports**: [GitHub Issues](https://github.com/provero-org/provero/issues)
-- **Real-time chat**: [Slack](https://provero.slack.com)
+- **Real-time chat**: [Slack](https://join.slack.com/t/provero/shared_invite/zt-3sj71s3ic-ey5Gf~Ls_YcmdMKkDz9oAQ)
 - **Security issues**: see [SECURITY.md](SECURITY.md)
 
 ## Before opening an issue


### PR DESCRIPTION
## Summary
- Replace `provero.slack.com` with public shared invite link in CONTRIBUTING.md and SUPPORT.md
- Allows anyone to join the Slack workspace without needing prior approval or an approved email domain

## Test plan
- [ ] Verify the invite link works by opening it in an incognito browser