### PR TITLE
Fix version display to read from package metadata

### DIFF
--- a/provero-core/src/provero/__init__.py
+++ b/provero-core/src/provero/__init__.py
@@ -17,4 +17,9 @@
 
 """Provero - A vendor-neutral, declarative data quality engine."""
 
-__version__ = "0.0.1"
+try:
+    from importlib.metadata import version
+
+    __version__ = version("provero")
+except Exception:
+    __version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- `provero version` showed `0.0.1` instead of `0.1.0` because `__version__` was hardcoded
- Now reads from `importlib.metadata` with fallback

## Test plan
- [x] `uv run python -c "from provero import __version__; print(__version__)"` returns `0.1.0`
- [x] 325 tests pass