### PR TITLE
Fix JSON output control characters on check failures

### DIFF
--- a/newsfragments/85.bugfix.md
+++ b/newsfragments/85.bugfix.md
@@ -1,0 +1,1 @@
+Fix JSON output containing invalid control characters when checks fail.

--- a/provero-core/src/provero/cli/main.py
+++ b/provero-core/src/provero/cli/main.py
@@ -311,7 +311,7 @@ def run(
             # table format is suppressed entirely in quiet mode.
         else:
             if output_format == "json":
-                console.print(result.model_dump_json(indent=2))
+                typer.echo(result.model_dump_json(indent=2))
             elif output_format == "csv":
                 _print_csv(result, include_header=not csv_header_written)
                 csv_header_written = True

--- a/provero-core/tests/test_e2e_realistic.py
+++ b/provero-core/tests/test_e2e_realistic.py
@@ -277,9 +277,6 @@ class TestCLIWithFailures:
         assert result.exit_code == 1, f"Expected exit_code 1, got {result.exit_code}"
         assert "FAIL" in result.output
 
-    @pytest.mark.xfail(
-        reason="Issue #85: JSON contains invalid control characters when checks fail"
-    )
     def test_json_output_with_failures(self, cli_runner, dirty_db, tmp_path, monkeypatch):
         """JSON output with failing checks should be valid JSON."""
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary
- Replace `console.print()` with `typer.echo()` for JSON output in the `run` command, preventing Rich from injecting ANSI escape sequences into structured output
- Remove the `@pytest.mark.xfail` decorator from the now-passing test
- Add newsfragment for the bugfix

Closes #85

## Test plan
- [x] `test_json_output_with_failures` passes (was xfail)
- [x] Full test suite passes (331 passed, 35 skipped)
- [x] Ruff linting passes