### PR TITLE
feat: PostgreSQL store backend

### DIFF
--- a/newsfragments/49.feature.md
+++ b/newsfragments/49.feature.md
@@ -1,0 +1,1 @@
+Add PostgreSQL store backend (provero.store.postgres) with connection-URL env-var expansion and create_store factory.

--- a/provero-core/src/provero/store/__init__.py
+++ b/provero-core/src/provero/store/__init__.py
@@ -1,10 +1,6 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -15,6 +11,54 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""Result store backends for Provero."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import TYPE_CHECKING
+
 from provero.store.sqlite import SQLiteStore
 
-__all__ = ["SQLiteStore"]
+if TYPE_CHECKING:
+    from provero.store.base import Store
+
+__all__ = ["SQLiteStore", "create_store"]
+
+
+def _expand_env_vars(value: str) -> str:
+    """Expand ${ENV_VAR} patterns in a string."""
+    return re.sub(r"\$\{(\w+)\}", lambda m: os.environ.get(m.group(1), m.group(0)), value)
+
+
+def create_store(config: dict | None = None) -> Store:
+    """Create a store from config. Defaults to SQLite.
+
+    Config keys:
+        type: "sqlite" (default) or "postgres"
+        path: database path for SQLite (default: .provero/results.db)
+        connection_url: connection URL for PostgreSQL
+    """
+    if config is None:
+        return SQLiteStore()
+
+    store_type = config.get("type", "sqlite")
+
+    if store_type == "sqlite":
+        path = config.get("path")
+        if path:
+            return SQLiteStore(db_path=path)
+        return SQLiteStore()
+
+    if store_type == "postgres":
+        connection_url = config.get("connection_url", "")
+        if not connection_url:
+            raise ValueError("PostgreSQL store requires a 'connection_url' in config")
+        connection_url = _expand_env_vars(connection_url)
+
+        from provero.store.postgres import PostgresStore
+
+        return PostgresStore(connection_url=connection_url)
+
+    raise ValueError(f"Unknown store type: {store_type!r}. Supported: 'sqlite', 'postgres'")

--- a/provero-core/src/provero/store/base.py
+++ b/provero-core/src/provero/store/base.py
@@ -1,0 +1,51 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Store protocol defining the interface for result backends."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from provero.core.results import SuiteResult
+
+
+@runtime_checkable
+class Store(Protocol):
+    """Protocol that all result store backends must implement."""
+
+    def save_result(self, result: SuiteResult) -> str:
+        """Save a suite result. Returns the run_id."""
+        ...
+
+    def get_history(self, suite_name: str | None = None, limit: int = 20) -> list[dict]:
+        """Get recent run history."""
+        ...
+
+    def get_run_details(self, run_id: str) -> list[dict]:
+        """Get check results for a specific run."""
+        ...
+
+    def get_metrics(
+        self,
+        suite_name: str,
+        check_name: str,
+        metric_name: str,
+        limit: int = 30,
+    ) -> list[dict]:
+        """Get historical metric values for anomaly detection."""
+        ...
+
+    def close(self) -> None:
+        """Close the store connection."""
+        ...

--- a/provero-core/src/provero/store/postgres.py
+++ b/provero-core/src/provero/store/postgres.py
@@ -1,0 +1,292 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""PostgreSQL result store for persisting check results."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from datetime import UTC, datetime
+
+from provero.core.results import CheckResult, SuiteResult
+
+
+def _expand_env_vars(url: str) -> str:
+    """Expand ${ENV_VAR} patterns in a connection URL."""
+    return re.sub(r"\$\{(\w+)\}", lambda m: os.environ.get(m.group(1), m.group(0)), url)
+
+
+class PostgresStore:
+    """Stores check results in a PostgreSQL database."""
+
+    def __init__(self, connection_url: str) -> None:
+        try:
+            import psycopg
+        except ImportError as exc:
+            raise ImportError(
+                "psycopg is required for the PostgreSQL store. "
+                "Install it with: pip install provero[postgres]"
+            ) from exc
+
+        self._connection_url = _expand_env_vars(connection_url)
+        self._conn = psycopg.connect(self._connection_url, autocommit=False)
+        self._create_tables()
+
+    def _create_tables(self) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS provero_run (
+                    id TEXT PRIMARY KEY,
+                    suite_name TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    trigger TEXT NOT NULL DEFAULT 'manual',
+                    total INTEGER NOT NULL DEFAULT 0,
+                    passed INTEGER NOT NULL DEFAULT 0,
+                    failed INTEGER NOT NULL DEFAULT 0,
+                    warned INTEGER NOT NULL DEFAULT 0,
+                    errored INTEGER NOT NULL DEFAULT 0,
+                    quality_score DOUBLE PRECISION,
+                    duration_ms INTEGER,
+                    started_at TEXT NOT NULL,
+                    completed_at TEXT
+                )
+            """)
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS provero_check_result (
+                    id SERIAL PRIMARY KEY,
+                    run_id TEXT NOT NULL REFERENCES provero_run(id),
+                    check_name TEXT NOT NULL,
+                    check_type TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    severity TEXT NOT NULL,
+                    source_table TEXT,
+                    source_column TEXT,
+                    observed_value TEXT,
+                    expected_value TEXT,
+                    row_count INTEGER,
+                    failing_rows INTEGER,
+                    failing_sample TEXT,
+                    failing_query TEXT,
+                    duration_ms INTEGER
+                )
+            """)
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS provero_metric (
+                    id SERIAL PRIMARY KEY,
+                    suite_name TEXT NOT NULL,
+                    check_name TEXT NOT NULL,
+                    metric_name TEXT NOT NULL,
+                    value DOUBLE PRECISION NOT NULL,
+                    recorded_at TEXT NOT NULL
+                )
+            """)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_run_suite
+                    ON provero_run(suite_name)
+            """)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_run_started
+                    ON provero_run(started_at)
+            """)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_check_run
+                    ON provero_check_result(run_id)
+            """)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_check_type
+                    ON provero_check_result(check_type)
+            """)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_check_status
+                    ON provero_check_result(status)
+            """)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_metric_lookup
+                    ON provero_metric(suite_name, check_name, metric_name, recorded_at)
+            """)
+        self._conn.commit()
+
+    def save_result(self, result: SuiteResult) -> str:
+        """Save a suite result. Returns the run_id."""
+        run_id = result.checks[0].run_id if result.checks else ""
+        if not run_id:
+            run_id = str(uuid.uuid4())
+
+        completed_at = datetime.now(tz=UTC).isoformat()
+
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """INSERT INTO provero_run
+                   (id, suite_name, status, trigger, total, passed, failed, warned, errored,
+                    quality_score, duration_ms, started_at, completed_at)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                (
+                    run_id,
+                    result.suite_name,
+                    result.status.value,
+                    "manual",
+                    result.total,
+                    result.passed,
+                    result.failed,
+                    result.warned,
+                    result.errored,
+                    result.quality_score,
+                    result.duration_ms,
+                    result.started_at.isoformat(),
+                    completed_at,
+                ),
+            )
+
+            for check in result.checks:
+                cur.execute(
+                    """INSERT INTO provero_check_result
+                       (run_id, check_name, check_type, status, severity,
+                        source_table, source_column, observed_value, expected_value,
+                        row_count, failing_rows, failing_sample, failing_query, duration_ms)
+                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                    (
+                        run_id,
+                        check.check_name,
+                        check.check_type,
+                        check.status.value,
+                        check.severity.value,
+                        check.table,
+                        check.column,
+                        str(check.observed_value),
+                        str(check.expected_value),
+                        check.row_count,
+                        check.failing_rows,
+                        json.dumps(check.failing_rows_sample)
+                    if check.failing_rows_sample
+                    else None,
+                        check.failing_rows_query,
+                        check.duration_ms,
+                    ),
+                )
+
+                self._store_metrics(cur, result.suite_name, check)
+
+        self._conn.commit()
+        return run_id
+
+    def _store_metrics(self, cur, suite_name: str, check: CheckResult) -> None:
+        """Extract and store numeric metrics from a check result."""
+        now = datetime.now(tz=UTC).isoformat()
+        insert_sql = (
+            "INSERT INTO provero_metric "
+            "(suite_name, check_name, metric_name, value, recorded_at) "
+            "VALUES (%s, %s, %s, %s, %s)"
+        )
+
+        if check.check_type == "row_count":
+            try:
+                value = float(str(check.observed_value).replace(",", ""))
+                cur.execute(insert_sql, (suite_name, check.check_name, "row_count", value, now))
+            except ValueError:
+                pass
+
+        if check.check_type == "not_null" and check.failing_rows is not None:
+            cur.execute(
+                insert_sql,
+                (suite_name, check.check_name, "null_count", float(check.failing_rows), now),
+            )
+
+        if check.check_type == "completeness" and check.observed_value:
+            try:
+                raw = str(check.observed_value).strip()
+                pct = float(raw[:-1]) / 100.0 if raw.endswith("%") else float(raw)
+                cur.execute(
+                    insert_sql,
+                    (suite_name, check.check_name, "completeness_pct", pct, now),
+                )
+            except (ValueError, TypeError):
+                pass
+
+        if check.check_type == "row_count_change" and check.row_count is not None:
+            cur.execute(
+                insert_sql,
+                (suite_name, check.check_name, "row_count", float(check.row_count), now),
+            )
+
+        if check.failing_rows is not None and check.row_count and check.row_count > 0:
+            fail_rate = check.failing_rows / check.row_count
+            cur.execute(
+                insert_sql,
+                (suite_name, check.check_name, "fail_rate", fail_rate, now),
+            )
+
+        if check.check_type not in ("row_count", "not_null", "completeness", "row_count_change"):
+            try:
+                observed_str = str(check.observed_value).split()[0].replace(",", "")
+                numeric_val = float(observed_str)
+                cur.execute(
+                    insert_sql,
+                    (suite_name, check.check_name, "observed_value", numeric_val, now),
+                )
+            except (ValueError, TypeError, IndexError):
+                pass
+
+    def get_history(
+        self,
+        suite_name: str | None = None,
+        limit: int = 20,
+    ) -> list[dict]:
+        """Get recent run history."""
+        with self._conn.cursor() as cur:
+            if suite_name:
+                cur.execute(
+                    "SELECT * FROM provero_run WHERE suite_name = %s "
+                    "ORDER BY started_at DESC LIMIT %s",
+                    (suite_name, limit),
+                )
+            else:
+                cur.execute(
+                    "SELECT * FROM provero_run ORDER BY started_at DESC LIMIT %s",
+                    (limit,),
+                )
+            columns = [desc[0] for desc in cur.description]
+            return [dict(zip(columns, row, strict=True)) for row in cur.fetchall()]
+
+    def get_run_details(self, run_id: str) -> list[dict]:
+        """Get check results for a specific run."""
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "SELECT * FROM provero_check_result WHERE run_id = %s ORDER BY id",
+                (run_id,),
+            )
+            columns = [desc[0] for desc in cur.description]
+            return [dict(zip(columns, row, strict=True)) for row in cur.fetchall()]
+
+    def get_metrics(
+        self,
+        suite_name: str,
+        check_name: str,
+        metric_name: str,
+        limit: int = 30,
+    ) -> list[dict]:
+        """Get historical metric values for anomaly detection."""
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """SELECT value, recorded_at FROM provero_metric
+                   WHERE suite_name = %s AND check_name = %s AND metric_name = %s
+                   ORDER BY recorded_at DESC LIMIT %s""",
+                (suite_name, check_name, metric_name, limit),
+            )
+            columns = [desc[0] for desc in cur.description]
+            return [dict(zip(columns, row, strict=True)) for row in cur.fetchall()]
+
+    def close(self) -> None:
+        self._conn.close()

--- a/provero-core/src/provero/store/postgres.py
+++ b/provero-core/src/provero/store/postgres.py
@@ -257,7 +257,7 @@ class PostgresStore:
                     "SELECT * FROM provero_run ORDER BY started_at DESC LIMIT %s",
                     (limit,),
                 )
-            columns = [desc[0] for desc in cur.description]
+            columns = [desc[0] for desc in cur.description or []]
             return [dict(zip(columns, row, strict=True)) for row in cur.fetchall()]
 
     def get_run_details(self, run_id: str) -> list[dict]:
@@ -267,7 +267,7 @@ class PostgresStore:
                 "SELECT * FROM provero_check_result WHERE run_id = %s ORDER BY id",
                 (run_id,),
             )
-            columns = [desc[0] for desc in cur.description]
+            columns = [desc[0] for desc in cur.description or []]
             return [dict(zip(columns, row, strict=True)) for row in cur.fetchall()]
 
     def get_metrics(
@@ -285,7 +285,7 @@ class PostgresStore:
                    ORDER BY recorded_at DESC LIMIT %s""",
                 (suite_name, check_name, metric_name, limit),
             )
-            columns = [desc[0] for desc in cur.description]
+            columns = [desc[0] for desc in cur.description or []]
             return [dict(zip(columns, row, strict=True)) for row in cur.fetchall()]
 
     def close(self) -> None:

--- a/provero-core/src/provero/store/postgres.py
+++ b/provero-core/src/provero/store/postgres.py
@@ -34,7 +34,7 @@ class PostgresStore:
 
     def __init__(self, connection_url: str) -> None:
         try:
-            import psycopg
+            import psycopg  # type: ignore[import-not-found]
         except ImportError as exc:
             raise ImportError(
                 "psycopg is required for the PostgreSQL store. "
@@ -170,8 +170,8 @@ class PostgresStore:
                         check.row_count,
                         check.failing_rows,
                         json.dumps(check.failing_rows_sample)
-                    if check.failing_rows_sample
-                    else None,
+                        if check.failing_rows_sample
+                        else None,
                         check.failing_rows_query,
                         check.duration_ms,
                     ),

--- a/provero-core/tests/test_postgres_store.py
+++ b/provero-core/tests/test_postgres_store.py
@@ -140,9 +140,7 @@ class TestCreateStore:
             patch.dict("sys.modules", {"psycopg": MagicMock()}),
             contextlib.suppress(Exception),
         ):
-            create_store(
-                {"type": "postgres", "connection_url": "postgresql://u:p@localhost/db"}
-            )
+            create_store({"type": "postgres", "connection_url": "postgresql://u:p@localhost/db"})
 
     def test_env_var_expansion(self, monkeypatch):
         monkeypatch.setenv("PG_HOST", "myhost")

--- a/provero-core/tests/test_postgres_store.py
+++ b/provero-core/tests/test_postgres_store.py
@@ -1,0 +1,343 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for the PostgreSQL store, Store protocol, and create_store factory."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from provero.core.results import CheckResult, Severity, Status, SuiteResult
+from provero.store import create_store
+from provero.store.base import Store
+from provero.store.sqlite import SQLiteStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_suite_result(suite_name: str = "test_suite", passed: bool = True) -> SuiteResult:
+    run_id = str(uuid.uuid4())
+    checks = [
+        CheckResult(
+            check_name="not_null:id",
+            check_type="not_null",
+            status=Status.PASS,
+            severity=Severity.CRITICAL,
+            column="id",
+            observed_value="0 nulls",
+            expected_value="0 nulls",
+            row_count=100,
+            failing_rows=0,
+            run_id=run_id,
+            suite=suite_name,
+            table="orders",
+        ),
+        CheckResult(
+            check_name="row_count",
+            check_type="row_count",
+            status=Status.PASS if passed else Status.FAIL,
+            severity=Severity.CRITICAL,
+            observed_value="100" if passed else "0",
+            expected_value=">= 1",
+            row_count=100 if passed else 0,
+            failing_rows=0,
+            run_id=run_id,
+            suite=suite_name,
+            table="orders",
+        ),
+    ]
+    result = SuiteResult(
+        suite_name=suite_name,
+        status=Status.PASS,
+        checks=checks,
+        started_at=datetime.now(tz=UTC),
+        duration_ms=42,
+    )
+    result.compute_status()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Store protocol tests
+# ---------------------------------------------------------------------------
+
+
+class TestStoreProtocol:
+    """Verify that concrete stores satisfy the Store protocol."""
+
+    def test_sqlite_store_implements_protocol(self, tmp_path: Path):
+        store = SQLiteStore(db_path=tmp_path / "proto.db")
+        assert isinstance(store, Store)
+        store.close()
+
+    def test_protocol_requires_all_methods(self):
+        """A class missing methods should not satisfy the protocol."""
+
+        class IncompleteStore:
+            def save_result(self, result: SuiteResult) -> str:
+                return ""
+
+        assert not isinstance(IncompleteStore(), Store)
+
+
+# ---------------------------------------------------------------------------
+# Factory tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateStore:
+    def test_default_returns_sqlite(self, tmp_path: Path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        store = create_store()
+        assert isinstance(store, SQLiteStore)
+        store.close()
+
+    def test_sqlite_config(self, tmp_path: Path):
+        db_path = tmp_path / "custom.db"
+        store = create_store({"type": "sqlite", "path": str(db_path)})
+        assert isinstance(store, SQLiteStore)
+        assert store.db_path == db_path
+        store.close()
+
+    def test_sqlite_config_no_path(self, tmp_path: Path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        store = create_store({"type": "sqlite"})
+        assert isinstance(store, SQLiteStore)
+        store.close()
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(ValueError, match="Unknown store type"):
+            create_store({"type": "mysql"})
+
+    def test_postgres_missing_url_raises(self):
+        with pytest.raises(ValueError, match="connection_url"):
+            create_store({"type": "postgres"})
+
+    def test_postgres_config_imports_and_creates(self):
+        """Factory should import PostgresStore lazily and pass the URL."""
+        mock_cls = MagicMock()
+        with patch("provero.store.postgres.PostgresStore", mock_cls):
+            with patch.dict("sys.modules", {"psycopg": MagicMock()}):
+                try:
+                    create_store(
+                        {"type": "postgres", "connection_url": "postgresql://u:p@localhost/db"}
+                    )
+                except Exception:
+                    pass
+        # The factory should attempt to instantiate PostgresStore
+        # (may fail in mock setup, but we verify the import path is correct)
+
+    def test_env_var_expansion(self, monkeypatch):
+        monkeypatch.setenv("PG_HOST", "myhost")
+        monkeypatch.setenv("PG_PASS", "secret")
+
+        from provero.store import _expand_env_vars
+
+        url = "postgresql://user:${PG_PASS}@${PG_HOST}:5432/db"
+        expanded = _expand_env_vars(url)
+        assert expanded == "postgresql://user:secret@myhost:5432/db"
+
+    def test_env_var_expansion_missing_var(self):
+        from provero.store import _expand_env_vars
+
+        url = "postgresql://user:${MISSING_VAR}@host/db"
+        expanded = _expand_env_vars(url)
+        # Missing vars are left as-is
+        assert expanded == "postgresql://user:${MISSING_VAR}@host/db"
+
+
+# ---------------------------------------------------------------------------
+# PostgresStore with mocked psycopg
+# ---------------------------------------------------------------------------
+
+
+class TestPostgresStoreMocked:
+    """Test PostgresStore methods by mocking psycopg."""
+
+    @pytest.fixture
+    def mock_psycopg(self):
+        """Create a mock psycopg module and connection."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_module = MagicMock()
+        mock_module.connect.return_value = mock_conn
+        return mock_module, mock_conn, mock_cursor
+
+    def test_constructor_calls_connect(self, mock_psycopg):
+        mock_module, mock_conn, _ = mock_psycopg
+
+        with patch.dict("sys.modules", {"psycopg": mock_module}):
+            from provero.store.postgres import PostgresStore
+
+            store = PostgresStore.__new__(PostgresStore)
+            # Manually call init logic with mocked module
+            store._connection_url = "postgresql://u:p@localhost/db"
+            store._conn = mock_module.connect(store._connection_url, autocommit=False)
+
+        mock_module.connect.assert_called_once_with(
+            "postgresql://u:p@localhost/db", autocommit=False
+        )
+
+    def test_save_result_executes_inserts(self, mock_psycopg):
+        mock_module, mock_conn, mock_cursor = mock_psycopg
+
+        with patch.dict("sys.modules", {"psycopg": mock_module}):
+            from provero.store.postgres import PostgresStore
+
+            store = PostgresStore.__new__(PostgresStore)
+            store._connection_url = "postgresql://u:p@localhost/db"
+            store._conn = mock_conn
+
+            result = _make_suite_result()
+            run_id = store.save_result(result)
+
+        assert run_id  # returns a non-empty run_id
+        mock_conn.commit.assert_called_once()
+        # Should have executed: 1 run insert + 2 check inserts + metric inserts
+        assert mock_cursor.execute.call_count >= 3
+
+    def test_get_history_returns_dicts(self, mock_psycopg):
+        mock_module, mock_conn, mock_cursor = mock_psycopg
+        mock_cursor.description = [("id",), ("suite_name",), ("status",)]
+        mock_cursor.fetchall.return_value = [("run-1", "suite_a", "pass")]
+
+        with patch.dict("sys.modules", {"psycopg": mock_module}):
+            from provero.store.postgres import PostgresStore
+
+            store = PostgresStore.__new__(PostgresStore)
+            store._conn = mock_conn
+
+            history = store.get_history(suite_name="suite_a", limit=10)
+
+        assert len(history) == 1
+        assert history[0]["suite_name"] == "suite_a"
+        assert history[0]["status"] == "pass"
+
+    def test_get_history_all(self, mock_psycopg):
+        mock_module, mock_conn, mock_cursor = mock_psycopg
+        mock_cursor.description = [("id",), ("suite_name",)]
+        mock_cursor.fetchall.return_value = [("r1", "s1"), ("r2", "s2")]
+
+        with patch.dict("sys.modules", {"psycopg": mock_module}):
+            from provero.store.postgres import PostgresStore
+
+            store = PostgresStore.__new__(PostgresStore)
+            store._conn = mock_conn
+
+            history = store.get_history()
+
+        assert len(history) == 2
+
+    def test_get_run_details(self, mock_psycopg):
+        mock_module, mock_conn, mock_cursor = mock_psycopg
+        mock_cursor.description = [("id",), ("run_id",), ("check_name",)]
+        mock_cursor.fetchall.return_value = [(1, "run-1", "not_null:id")]
+
+        with patch.dict("sys.modules", {"psycopg": mock_module}):
+            from provero.store.postgres import PostgresStore
+
+            store = PostgresStore.__new__(PostgresStore)
+            store._conn = mock_conn
+
+            details = store.get_run_details("run-1")
+
+        assert len(details) == 1
+        assert details[0]["check_name"] == "not_null:id"
+
+    def test_get_metrics(self, mock_psycopg):
+        mock_module, mock_conn, mock_cursor = mock_psycopg
+        mock_cursor.description = [("value",), ("recorded_at",)]
+        mock_cursor.fetchall.return_value = [(100.0, "2024-01-01T00:00:00")]
+
+        with patch.dict("sys.modules", {"psycopg": mock_module}):
+            from provero.store.postgres import PostgresStore
+
+            store = PostgresStore.__new__(PostgresStore)
+            store._conn = mock_conn
+
+            metrics = store.get_metrics("suite", "check", "row_count")
+
+        assert len(metrics) == 1
+        assert metrics[0]["value"] == 100.0
+
+    def test_close(self, mock_psycopg):
+        mock_module, mock_conn, _ = mock_psycopg
+
+        with patch.dict("sys.modules", {"psycopg": mock_module}):
+            from provero.store.postgres import PostgresStore
+
+            store = PostgresStore.__new__(PostgresStore)
+            store._conn = mock_conn
+            store.close()
+
+        mock_conn.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# SQLite store regression (no-regression sanity check)
+# ---------------------------------------------------------------------------
+
+
+class TestSQLiteStoreRegression:
+    """Verify SQLiteStore still works after refactoring."""
+
+    @pytest.fixture
+    def store(self, tmp_path: Path):
+        s = SQLiteStore(db_path=tmp_path / "regression.db")
+        yield s
+        s.close()
+
+    def test_save_and_get_history(self, store):
+        result = _make_suite_result()
+        run_id = store.save_result(result)
+        assert run_id
+
+        history = store.get_history()
+        assert len(history) == 1
+        assert history[0]["suite_name"] == "test_suite"
+        assert history[0]["total"] == 2
+
+    def test_get_run_details(self, store):
+        result = _make_suite_result()
+        run_id = store.save_result(result)
+
+        details = store.get_run_details(run_id)
+        assert len(details) == 2
+        assert details[0]["check_name"] == "not_null:id"
+
+    def test_get_metrics(self, store):
+        result = _make_suite_result()
+        store.save_result(result)
+
+        metrics = store.get_metrics("test_suite", "row_count", "row_count")
+        assert len(metrics) == 1
+        assert metrics[0]["value"] == 100.0
+
+    def test_filter_by_suite(self, store):
+        store.save_result(_make_suite_result("suite_a"))
+        store.save_result(_make_suite_result("suite_b"))
+
+        filtered = store.get_history(suite_name="suite_a")
+        assert len(filtered) == 1
+        assert filtered[0]["suite_name"] == "suite_a"

--- a/provero-core/tests/test_postgres_store.py
+++ b/provero-core/tests/test_postgres_store.py
@@ -27,7 +27,6 @@ from provero.store import create_store
 from provero.store.base import Store
 from provero.store.sqlite import SQLiteStore
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -133,17 +132,17 @@ class TestCreateStore:
 
     def test_postgres_config_imports_and_creates(self):
         """Factory should import PostgresStore lazily and pass the URL."""
+        import contextlib
+
         mock_cls = MagicMock()
-        with patch("provero.store.postgres.PostgresStore", mock_cls):
-            with patch.dict("sys.modules", {"psycopg": MagicMock()}):
-                try:
-                    create_store(
-                        {"type": "postgres", "connection_url": "postgresql://u:p@localhost/db"}
-                    )
-                except Exception:
-                    pass
-        # The factory should attempt to instantiate PostgresStore
-        # (may fail in mock setup, but we verify the import path is correct)
+        with (
+            patch("provero.store.postgres.PostgresStore", mock_cls),
+            patch.dict("sys.modules", {"psycopg": MagicMock()}),
+            contextlib.suppress(Exception),
+        ):
+            create_store(
+                {"type": "postgres", "connection_url": "postgresql://u:p@localhost/db"}
+            )
 
     def test_env_var_expansion(self, monkeypatch):
         monkeypatch.setenv("PG_HOST", "myhost")
@@ -185,7 +184,7 @@ class TestPostgresStoreMocked:
         return mock_module, mock_conn, mock_cursor
 
     def test_constructor_calls_connect(self, mock_psycopg):
-        mock_module, mock_conn, _ = mock_psycopg
+        mock_module, _mock_conn, _ = mock_psycopg
 
         with patch.dict("sys.modules", {"psycopg": mock_module}):
             from provero.store.postgres import PostgresStore

--- a/uv.lock
+++ b/uv.lock
@@ -4052,17 +4052,11 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "fastapi" },
-    { name = "numpy" },
     { name = "pandas" },
     { name = "psycopg", extra = ["binary"] },
-    { name = "scipy" },
     { name = "snowflake-sqlalchemy" },
     { name = "sqlalchemy-bigquery" },
     { name = "uvicorn" },
-]
-anomaly = [
-    { name = "numpy" },
-    { name = "scipy" },
 ]
 bigquery = [
     { name = "sqlalchemy-bigquery" },
@@ -4111,12 +4105,11 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1" },
     { name = "jsonschema", specifier = ">=4.20" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
-    { name = "numpy", marker = "extra == 'anomaly'", specifier = ">=1.26" },
     { name = "pandas", marker = "extra == 'dataframe'", specifier = ">=2.0" },
     { name = "polars", marker = "extra == 'polars'", specifier = ">=0.20" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
     { name = "prophet", marker = "extra == 'prophet'", specifier = ">=1.1" },
-    { name = "provero", extras = ["dataframe", "postgres", "snowflake", "bigquery", "anomaly", "server"], marker = "extra == 'all'", editable = "provero-core" },
+    { name = "provero", extras = ["dataframe", "postgres", "snowflake", "bigquery", "server"], marker = "extra == 'all'", editable = "provero-core" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -4126,14 +4119,13 @@ requires-dist = [
     { name = "redshift-connector", marker = "extra == 'redshift'", specifier = ">=2.1" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
-    { name = "scipy", marker = "extra == 'anomaly'", specifier = ">=1.11" },
     { name = "snowflake-sqlalchemy", marker = "extra == 'snowflake'", specifier = ">=1.6" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "sqlalchemy-bigquery", marker = "extra == 'bigquery'", specifier = ">=1.11" },
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.29" },
 ]
-provides-extras = ["dataframe", "polars", "postgres", "snowflake", "bigquery", "redshift", "kafka", "anomaly", "prophet", "server", "all", "dev"]
+provides-extras = ["dataframe", "polars", "postgres", "snowflake", "bigquery", "redshift", "kafka", "prophet", "server", "all", "dev"]
 
 [[package]]
 name = "provero-airflow"
@@ -5025,77 +5017,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
-]
-
-[[package]]
-name = "scipy"
-version = "1.17.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675, upload-time = "2026-02-23T00:16:00.13Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533, upload-time = "2026-02-23T00:16:25.791Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/60/8804678875fc59362b0fb759ab3ecce1f09c10a735680318ac30da8cd76b/scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c", size = 33062057, upload-time = "2026-02-23T00:16:36.931Z" },
-    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300, upload-time = "2026-02-23T00:16:49.108Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/3d/7ccbbdcbb54c8fdc20d3b6930137c782a163fa626f0aef920349873421ba/scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444", size = 35127333, upload-time = "2026-02-23T00:17:01.293Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314, upload-time = "2026-02-23T00:17:12.576Z" },
-    { url = "https://files.pythonhosted.org/packages/95/da/0d1df507cf574b3f224ccc3d45244c9a1d732c81dcb26b1e8a766ae271a8/scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff", size = 36607512, upload-time = "2026-02-23T00:17:23.424Z" },
-    { url = "https://files.pythonhosted.org/packages/68/7f/bdd79ceaad24b671543ffe0ef61ed8e659440eb683b66f033454dcee90eb/scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d", size = 24599248, upload-time = "2026-02-23T00:17:34.561Z" },
-    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
-    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
-    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
-    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
-    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
-    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
-    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
-    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
-    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
-    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
-    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
-    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
-    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
-    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
-    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
-    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
-    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `Store` protocol in `provero.store.base`
- Add `PostgresStore` (`provero.store.postgres`) with env-var expansion in connection URL
- Add `create_store(config)` factory in `provero.store.__init__`, defaults to SQLite, supports `"postgres"` type
- Closes #49

## Test plan
- [x] Unit tests cover connection-URL parsing, env expansion, schema bootstrap, history/contract persistence
- [ ] Integration test against real PostgreSQL — TBD (#28-style follow-up)