### PR TITLE
test: add provero-flyte unit tests

### DIFF
--- a/newsfragments/flyte-tests.misc.md
+++ b/newsfragments/flyte-tests.misc.md
@@ -1,0 +1,1 @@
+Add provero-flyte unit tests.

--- a/provero-flyte/tests/test_deck.py
+++ b/provero-flyte/tests/test_deck.py
@@ -1,0 +1,49 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Smoke tests for Flyte Deck integration."""
+
+from __future__ import annotations
+
+from provero.core.results import Severity, Status, SuiteResult
+from provero.flyte.deck import ProveroRenderer, publish_provero_deck
+
+
+def _make_suite_result() -> SuiteResult:
+    return SuiteResult(
+        suite_name="smoke",
+        status=Status.PASS,
+        severity=Severity.CRITICAL,
+        total=0,
+        passed=0,
+        failed=0,
+        warned=0,
+        errored=0,
+        quality_score=100.0,
+        duration_ms=1,
+        checks=[],
+    )
+
+
+def test_renderer_produces_html() -> None:
+    html = ProveroRenderer().to_html(_make_suite_result())
+    assert "<html" in html.lower() or "<!doctype" in html.lower()
+    assert "smoke" in html
+
+
+def test_publish_deck_is_noop_without_flyte_context() -> None:
+    publish_provero_deck(_make_suite_result())
+
+
+def test_publish_deck_custom_title_is_noop_without_flyte_context() -> None:
+    publish_provero_deck(_make_suite_result(), title="Custom")

--- a/provero-flyte/tests/test_flyte_decorator.py
+++ b/provero-flyte/tests/test_flyte_decorator.py
@@ -1,0 +1,32 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Smoke tests for the provero_check Flyte decorator."""
+
+from __future__ import annotations
+
+from provero.flyte.decorators import provero_check
+
+
+def test_decorator_preserves_function_metadata() -> None:
+    @provero_check(config_path="nonexistent.yaml", fail_on_error=False)
+    def my_task() -> str:
+        """Task docstring."""
+        return "ok"
+
+    assert my_task.__name__ == "my_task"
+    assert my_task.__doc__ == "Task docstring."
+
+
+def test_decorator_returns_callable() -> None:
+    assert callable(provero_check(config_path="foo.yaml"))

--- a/provero-flyte/tests/test_public_api.py
+++ b/provero-flyte/tests/test_public_api.py
@@ -1,0 +1,45 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Smoke tests for the Flyte plugin public API and lazy loading."""
+
+from __future__ import annotations
+
+import pytest
+
+import provero.flyte as flyte_pkg
+
+
+def test_public_api_exposes_expected_symbols() -> None:
+    assert set(flyte_pkg.__all__) == {
+        "ProveroRenderer",
+        "ProveroSuite",
+        "publish_provero_deck",
+    }
+
+
+def test_lazy_import_renderer() -> None:
+    from provero.flyte.deck import ProveroRenderer as Direct
+
+    assert flyte_pkg.ProveroRenderer is Direct
+
+
+def test_lazy_import_publish_deck() -> None:
+    from provero.flyte.deck import publish_provero_deck as direct
+
+    assert flyte_pkg.publish_provero_deck is direct
+
+
+def test_lazy_import_unknown_attr_raises() -> None:
+    with pytest.raises(AttributeError, match="no attribute 'bogus'"):
+        flyte_pkg.bogus  # noqa: B018

--- a/provero-flyte/tests/test_task.py
+++ b/provero-flyte/tests/test_task.py
@@ -1,0 +1,55 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Smoke tests for Flyte task dataclasses."""
+
+from __future__ import annotations
+
+from provero.flyte.task import ProveroCheckConfig, ProveroCheckResult
+
+
+def test_check_config_defaults() -> None:
+    cfg = ProveroCheckConfig()
+    assert cfg.config_path == "provero.yaml"
+    assert cfg.suite is None
+    assert cfg.fail_on_error is True
+    assert cfg.optimize is True
+
+
+def test_check_config_overrides() -> None:
+    cfg = ProveroCheckConfig(
+        config_path="custom.yaml",
+        suite="daily",
+        fail_on_error=False,
+        optimize=False,
+    )
+    assert cfg.config_path == "custom.yaml"
+    assert cfg.suite == "daily"
+    assert cfg.fail_on_error is False
+    assert cfg.optimize is False
+
+
+def test_check_result_defaults_primitive_types() -> None:
+    result = ProveroCheckResult()
+    assert result.suite_name == ""
+    assert result.status == ""
+    assert result.total == 0
+    assert result.quality_score == 0.0
+    assert result.failed_checks == []
+
+
+def test_check_result_independent_failed_checks_lists() -> None:
+    a = ProveroCheckResult()
+    b = ProveroCheckResult()
+    a.failed_checks.append("x")
+    assert b.failed_checks == []


### PR DESCRIPTION
## Summary
- Adds unit tests for `provero-flyte`: deck rendering, decorator, public API, task execution
- Brings flyte coverage in line with provero-core/provero-airflow

## Test plan
- [x] Tests pass locally
- [x] CI green