### PR TITLE
chore: drop unused scipy/numpy from [anomaly] extra

### DIFF
--- a/newsfragments/117.misc.md
+++ b/newsfragments/117.misc.md
@@ -1,0 +1,1 @@
+Drop unused scipy/numpy from the [anomaly] optional dependency.

--- a/provero-core/pyproject.toml
+++ b/provero-core/pyproject.toml
@@ -41,11 +41,10 @@ snowflake = ["snowflake-sqlalchemy>=1.6"]
 bigquery = ["sqlalchemy-bigquery>=1.11"]
 redshift = ["redshift-connector>=2.1"]
 kafka = ["confluent-kafka>=2.3"]
-anomaly = ["scipy>=1.11", "numpy>=1.26"]
 prophet = ["prophet>=1.1"]
 server = ["fastapi>=0.110", "uvicorn>=0.29"]
 all = [
-    "provero[dataframe,postgres,snowflake,bigquery,anomaly,server]",
+    "provero[dataframe,postgres,snowflake,bigquery,server]",
 ]
 dev = [
     "pytest>=8.0",


### PR DESCRIPTION
## Summary
- `provero.anomaly` uses only stdlib (`statistics`, `math`); scipy/numpy were declared but never imported
- Drop `anomaly = ["scipy>=1.11", "numpy>=1.26"]` extra
- Drop `anomaly` from `all` extra (no longer adds anything)
- Closes #117

## Test plan
- [x] CI green (anomaly tests use stdlib only, unaffected)