### PR TITLE
fix: profile --suggest emits freshness for timestamp columns

### DIFF
--- a/newsfragments/116.bugfix.md
+++ b/newsfragments/116.bugfix.md
@@ -1,0 +1,1 @@
+profile --suggest now emits a freshness check for timestamp/date columns instead of accepted_values.

--- a/provero-core/src/provero/core/profiler.py
+++ b/provero-core/src/provero/core/profiler.py
@@ -223,6 +223,13 @@ def suggest_checks(profile: TableProfile) -> list[dict[str, Any]]:
         if col.distinct_pct == 100 and col.total_count > 1:
             unique_cols.append(col.name)
 
+        # Suggest freshness for timestamp/date columns instead of accepted_values.
+        _ts_types = ("timestamp", "date", "time", "datetime", "timestamptz")
+        is_temporal_col = any(t in col.dtype.lower() for t in _ts_types)
+        if is_temporal_col:
+            checks.append({"freshness": {"column": col.name, "max_age": "24h"}})
+            continue
+
         # Suggest accepted_values for low-cardinality non-numeric columns.
         # For numeric columns, range checks are more appropriate.
         is_numeric_col = col.min_value is not None and col.max_value is not None

--- a/provero-core/tests/test_profiler.py
+++ b/provero-core/tests/test_profiler.py
@@ -125,6 +125,33 @@ class TestSuggestChecks:
         assert amount_check["range"]["min"] < 45.0
         assert amount_check["range"]["max"] > 999.99
 
+    def test_suggests_freshness_for_timestamp_columns(self):
+        connector = DuckDBConnector()
+        conn = connector.connect()
+        try:
+            conn._conn.execute("""
+                CREATE TABLE events (
+                    id INTEGER,
+                    created_at TIMESTAMP
+                )
+            """)
+            conn._conn.execute("""
+                INSERT INTO events VALUES
+                (1, '2026-01-01 00:00:00'),
+                (2, '2026-01-02 00:00:00'),
+                (3, '2026-01-03 00:00:00')
+            """)
+            profile = profile_table(conn, "events")
+            checks = suggest_checks(profile)
+
+            freshness_checks = [c for c in checks if "freshness" in c]
+            assert any(c["freshness"]["column"] == "created_at" for c in freshness_checks)
+
+            av_checks = [c for c in checks if "accepted_values" in c]
+            assert not any(c["accepted_values"]["column"] == "created_at" for c in av_checks)
+        finally:
+            connector.disconnect(conn)
+
     def test_suggests_row_count(self, orders_connection):
         profile = profile_table(orders_connection, "orders")
         checks = suggest_checks(profile)


### PR DESCRIPTION
## Summary
- Previously, low-cardinality timestamp/date columns produced `accepted_values` suggestions listing literal timestamps. Useless.
- Detect temporal dtypes (`timestamp`, `date`, `time`, `datetime`, `timestamptz`) and suggest `freshness` (24h `max_age`) instead, then skip `accepted_values` for the same column.
- Closes #116

## Test plan
- [x] New `test_suggests_freshness_for_timestamp_columns` covers TIMESTAMP detection and absence of accepted_values suggestion
- [x] Existing profile tests still pass