### PR TITLE
chore: rename workspace + add coverage config

### DIFF
--- a/newsfragments/workspace-rename.misc.md
+++ b/newsfragments/workspace-rename.misc.md
@@ -1,0 +1,1 @@
+Rename workspace package to provero-workspace and add coverage configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "apache-provero"
+name = "provero-workspace"
 version = "0.1.0-dev"
 description = "Provero workspace root"
 requires-python = ">=3.11"
@@ -49,6 +49,21 @@ select = [
 [tool.pytest.ini_options]
 testpaths = ["provero-core/tests"]
 pythonpath = ["provero-core/src"]
+
+[tool.coverage.run]
+source = ["provero-core/src/provero"]
+branch = true
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+skip_covered = false
+exclude_also = [
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "@abstractmethod",
+    "pragma: no cover",
+]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -18,10 +18,10 @@ resolution-markers = [
 
 [manifest]
 members = [
-    "apache-provero",
     "provero",
     "provero-airflow",
     "provero-flyte",
+    "provero-workspace",
 ]
 
 [[package]]
@@ -450,62 +450,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/bf/d437471dce6ffa15c8847d277cdb114e41e7076e0eb22e806d5d335f37c0/apache_airflow_task_sdk-1.1.8.tar.gz", hash = "sha256:d9b6027906a0e179c7ddc550c13717663785460a539b933741f22c47d10f4930", size = 1291245, upload-time = "2026-03-11T19:28:21.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/a9/9055473ca151dd630d0da2959f82ce2da13baf3a8cde6d7d5e3fdc5cd69e/apache_airflow_task_sdk-1.1.8-py3-none-any.whl", hash = "sha256:bd4d971b7450a297b4c9f59410b1d6bce482c349cd187b393a5b8842a2af57e3", size = 305695, upload-time = "2026-03-11T19:28:19.132Z" },
-]
-
-[[package]]
-name = "apache-provero"
-version = "0.1.0.dev0"
-source = { virtual = "." }
-dependencies = [
-    { name = "provero" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "hypothesis" },
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-    { name = "types-jsonschema" },
-    { name = "types-pyyaml" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "towncrier" },
-    { name = "types-jsonschema" },
-    { name = "types-pyyaml" },
-]
-docs = [
-    { name = "mkdocs-material" },
-    { name = "mkdocstrings", extra = ["python"] },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
-    { name = "provero", editable = "provero-core" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
-    { name = "types-jsonschema", marker = "extra == 'dev'", specifier = ">=4.20" },
-    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
-]
-provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "towncrier", specifier = ">=24.7" },
-    { name = "types-jsonschema", specifier = ">=4.20" },
-    { name = "types-pyyaml", specifier = ">=6.0" },
-]
-docs = [
-    { name = "mkdocs-material", specifier = ">=9.5" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.25" },
 ]
 
 [[package]]
@@ -4178,6 +4122,62 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
 ]
 provides-extras = ["polars", "dev"]
+
+[[package]]
+name = "provero-workspace"
+version = "0.1.0.dev0"
+source = { virtual = "." }
+dependencies = [
+    { name = "provero" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "hypothesis" },
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+    { name = "types-jsonschema" },
+    { name = "types-pyyaml" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "towncrier" },
+    { name = "types-jsonschema" },
+    { name = "types-pyyaml" },
+]
+docs = [
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
+    { name = "provero", editable = "provero-core" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
+    { name = "types-jsonschema", marker = "extra == 'dev'", specifier = ">=4.20" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "towncrier", specifier = ">=24.7" },
+    { name = "types-jsonschema", specifier = ">=4.20" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
+]
+docs = [
+    { name = "mkdocs-material", specifier = ">=9.5" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.25" },
+]
 
 [[package]]
 name = "psutil"


### PR DESCRIPTION
## Summary
- Rename workspace pyproject `name`: `apache-provero` → `provero-workspace`. Apache Foundation hasn't accepted the donation; reflects current state.
- Add `[tool.coverage.run]` with branch coverage on `provero-core/src/provero`
- Add `[tool.coverage.report]` with `fail_under = 80` and sensible `exclude_also` rules (NotImplementedError, TYPE_CHECKING, abstractmethod, pragma)

## Test plan
- [x] pytest still collects 511 tests
- [x] CI green