### PR TITLE
chore: pre-commit hooks + .gitignore updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,11 @@ ENV/
 # Testing
 .pytest_cache/
 .coverage
+.coverage.*
+coverage.xml
 htmlcov/
 .mypy_cache/
+.ruff_cache/
 
 # OS
 .DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,25 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-yaml
+      - id: check-toml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: check-merge-conflict
+      - id: detect-private-key
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        files: ^provero-core/src/
+        additional_dependencies:
+          - pydantic>=2.0
+          - types-pyyaml>=6.0
+          - types-jsonschema>=4.20

--- a/newsfragments/precommit-hooks.misc.md
+++ b/newsfragments/precommit-hooks.misc.md
@@ -1,0 +1,1 @@
+Add pre-commit hooks for YAML/TOML/whitespace/secrets validation and mypy. Update .gitignore.


### PR DESCRIPTION
## Summary
- Add pre-commit hooks: `check-yaml`, `check-toml`, `end-of-file-fixer`, `trailing-whitespace`, `check-added-large-files` (500kb cap), `check-merge-conflict`, `detect-private-key`
- Add `mypy` pre-commit hook scoped to `provero-core/src/` (with pydantic, types-pyyaml, types-jsonschema)
- `.gitignore`: add `.coverage.*`, `coverage.xml`, `.ruff_cache/`

## Out of scope
- CI workflow updates (`ci.yaml`) require larger coordination (cov-fail-under, multi-package lint/test) — defer to dedicated PR