### PR TITLE
feat: Airflow hooks + sensors

### DIFF
--- a/newsfragments/airflow-hooks-sensors.feature.md
+++ b/newsfragments/airflow-hooks-sensors.feature.md
@@ -1,0 +1,1 @@
+Add Airflow ProveroPipelineHook and ProveroSensor + integration tests.

--- a/provero-airflow/src/provero/airflow/__init__.py
+++ b/provero-airflow/src/provero/airflow/__init__.py
@@ -1,6 +1,10 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #

--- a/provero-airflow/src/provero/airflow/decorators.py
+++ b/provero-airflow/src/provero/airflow/decorators.py
@@ -1,6 +1,10 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #

--- a/provero-airflow/src/provero/airflow/hooks.py
+++ b/provero-airflow/src/provero/airflow/hooks.py
@@ -1,0 +1,128 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Provero Airflow hook wrapping the Python API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+try:
+    from airflow.hooks.base import BaseHook
+except ImportError:
+
+    class BaseHook:  # type: ignore[no-redef]
+        """Stub for when Airflow is not installed."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+
+class ProveroHook(BaseHook):
+    """Hook for running Provero data quality checks from Airflow.
+
+    Wraps the Provero Python API for use in operators, sensors, and
+    PythonOperator callables. Handles config loading, suite execution,
+    and result storage.
+
+    Example usage in a PythonOperator::
+
+        def run_checks(**context):
+            hook = ProveroHook(config_path="dags/provero.yaml")
+            results = hook.run_checks()
+            for suite in results:
+                if suite.status.value == "fail":
+                    raise ValueError(f"Suite {suite.suite_name} failed")
+
+        PythonOperator(
+            task_id="custom_check",
+            python_callable=run_checks,
+        )
+
+    :param config_path: Path to provero.yaml configuration file.
+    :param suite: Run only this suite (optional, runs all if not set).
+    :param optimize: Whether to use SQL batching optimization.
+    :param store_results: Whether to persist results to the local store.
+    """
+
+    conn_name_attr = "provero_conn_id"
+    default_conn_name = "provero_default"
+    conn_type = "provero"
+    hook_name = "Provero"
+
+    def __init__(
+        self,
+        config_path: str = "provero.yaml",
+        suite: str | None = None,
+        optimize: bool = True,
+        store_results: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.config_path = config_path
+        self.suite = suite
+        self.optimize = optimize
+        self.store_results = store_results
+
+    def run_checks(self) -> list:
+        """Execute quality checks and return a list of SuiteResult objects.
+
+        Returns:
+            List of SuiteResult objects, one per executed suite.
+        """
+        from provero.connectors.factory import create_connector
+        from provero.core.compiler import compile_file
+        from provero.core.engine import run_suite
+        from provero.store.sqlite import SQLiteStore
+
+        config = compile_file(Path(self.config_path))
+        results = []
+
+        store = SQLiteStore() if self.store_results else None
+        try:
+            for suite_config in config.suites:
+                if self.suite and suite_config.name != self.suite:
+                    continue
+                connector = create_connector(suite_config.source)
+                result = run_suite(suite_config, connector, optimize=self.optimize)
+                if store:
+                    store.save_result(result)
+                results.append(result)
+        finally:
+            if store:
+                store.close()
+
+        return results
+
+    def check_passed(self, suite_name: str | None = None) -> bool:
+        """Run checks and return True if all suites pass.
+
+        Args:
+            suite_name: Optional suite name to check. If not set,
+                uses the hook's configured suite filter.
+
+        Returns:
+            True if all executed suites passed, False otherwise.
+        """
+        from provero.core.results import Status
+
+        target = suite_name or self.suite
+        original_suite = self.suite
+        self.suite = target
+        try:
+            results = self.run_checks()
+        finally:
+            self.suite = original_suite
+
+        return all(r.status in (Status.PASS, Status.WARN) for r in results)

--- a/provero-airflow/src/provero/airflow/operators.py
+++ b/provero-airflow/src/provero/airflow/operators.py
@@ -1,10 +1,6 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -19,7 +15,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
 try:
@@ -73,37 +68,27 @@ class ProveroCheckOperator(BaseOperator):
         self.optimize = optimize
 
     def execute(self, context: Any) -> dict[str, Any]:
-        from provero.connectors.factory import create_connector
-        from provero.core.compiler import compile_file
-        from provero.core.engine import run_suite
+        from provero.airflow.hooks import ProveroHook
         from provero.core.results import Status
-        from provero.store.sqlite import SQLiteStore
 
-        config = compile_file(Path(self.config_path))
-        store = SQLiteStore()
+        hook = ProveroHook(
+            config_path=self.config_path,
+            suite=self.suite,
+            optimize=self.optimize,
+        )
+        results = hook.run_checks()
         all_results = []
 
-        try:
-            for suite_config in config.suites:
-                if self.suite and suite_config.name != self.suite:
-                    continue
+        for result in results:
+            all_results.append(result.model_dump())
 
-                connector = create_connector(suite_config.source)
-                result = run_suite(suite_config, connector, optimize=self.optimize)
-                store.save_result(result)
-                all_results.append(result.model_dump())
-
-                if self.fail_on_error and result.status == Status.FAIL:
-                    failed_checks = [
-                        c.check_name for c in result.checks if c.status == Status.FAIL
-                    ]
-                    msg = (
-                        f"Suite '{suite_config.name}' failed. "
-                        f"Score: {result.quality_score}/100. "
-                        f"Failed checks: {', '.join(failed_checks)}"
-                    )
-                    raise ValueError(msg)
-        finally:
-            store.close()
+            if self.fail_on_error and result.status == Status.FAIL:
+                failed_checks = [c.check_name for c in result.checks if c.status == Status.FAIL]
+                msg = (
+                    f"Suite '{result.suite_name}' failed. "
+                    f"Score: {result.quality_score}/100. "
+                    f"Failed checks: {', '.join(failed_checks)}"
+                )
+                raise ValueError(msg)
 
         return {"suites": all_results}

--- a/provero-airflow/src/provero/airflow/sensors.py
+++ b/provero-airflow/src/provero/airflow/sensors.py
@@ -1,0 +1,95 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Provero Airflow sensor that waits for data quality checks to pass."""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from airflow.sensors.base import BaseSensorOperator
+except ImportError:
+
+    class BaseSensorOperator:  # type: ignore[no-redef]
+        """Stub for when Airflow is not installed."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            self.task_id = kwargs.get("task_id", "")
+            self.poke_interval = kwargs.get("poke_interval", 60)
+            self.timeout = kwargs.get("timeout", 3600)
+            self.mode = kwargs.get("mode", "poke")
+
+        def poke(self, context: Any) -> bool:
+            raise NotImplementedError
+
+
+class ProveroSensor(BaseSensorOperator):
+    """Sensor that waits for Provero quality checks to pass.
+
+    Re-runs checks on each poke until all pass or the sensor times out.
+    Useful for gating downstream tasks on data quality.
+
+    Example::
+
+        wait_for_quality = ProveroSensor(
+            task_id="wait_for_quality",
+            config_path="dags/provero.yaml",
+            suite="orders_daily",
+            poke_interval=120,
+            timeout=3600,
+            mode="reschedule",
+        )
+
+        wait_for_quality >> transform >> load
+
+    :param config_path: Path to provero.yaml configuration file.
+    :param suite: Name of the suite to check (optional, checks all if not set).
+    :param optimize: Whether to use SQL batching optimization.
+    :param store_results: Whether to persist results to the local store.
+    :param poke_interval: Seconds between each check attempt (default 60).
+    :param timeout: Seconds before the sensor times out (default 3600).
+    :param mode: ``"poke"`` (default) or ``"reschedule"`` to free the worker slot between pokes.
+    """
+
+    template_fields = ("config_path", "suite")
+
+    def __init__(
+        self,
+        config_path: str = "provero.yaml",
+        suite: str | None = None,
+        optimize: bool = True,
+        store_results: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.config_path = config_path
+        self.suite = suite
+        self.optimize = optimize
+        self.store_results = store_results
+
+    def poke(self, context: Any) -> bool:
+        """Run checks and return True if all pass.
+
+        Called by Airflow on each poke interval. Returns True when all
+        quality checks pass, allowing downstream tasks to proceed.
+        """
+        from provero.airflow.hooks import ProveroHook
+
+        hook = ProveroHook(
+            config_path=self.config_path,
+            suite=self.suite,
+            optimize=self.optimize,
+            store_results=self.store_results,
+        )
+        return hook.check_passed()

--- a/provero-airflow/tests/test_airflow_decorator.py
+++ b/provero-airflow/tests/test_airflow_decorator.py
@@ -1,0 +1,33 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Smoke tests for the provero_check Airflow decorator."""
+
+from __future__ import annotations
+
+from provero.airflow.decorators import provero_check
+
+
+def test_decorator_preserves_function_metadata() -> None:
+    @provero_check(config_path="nonexistent.yaml", fail_on_error=False)
+    def my_task() -> str:
+        """Task docstring."""
+        return "ok"
+
+    assert my_task.__name__ == "my_task"
+    assert my_task.__doc__ == "Task docstring."
+
+
+def test_decorator_returns_callable() -> None:
+    decorator = provero_check(config_path="foo.yaml", suite="bar")
+    assert callable(decorator)

--- a/provero-airflow/tests/test_hook.py
+++ b/provero-airflow/tests/test_hook.py
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Smoke tests for ProveroHook metadata and construction."""
+
+from __future__ import annotations
+
+from provero.airflow.hooks import ProveroHook
+
+
+def test_hook_connection_metadata() -> None:
+    assert ProveroHook.conn_type == "provero"
+    assert ProveroHook.conn_name_attr == "provero_conn_id"
+    assert ProveroHook.default_conn_name == "provero_default"
+    assert ProveroHook.hook_name == "Provero"
+
+
+def test_hook_constructs_with_defaults() -> None:
+    hook = ProveroHook()
+    assert hook.config_path == "provero.yaml"
+    assert hook.suite is None
+    assert hook.optimize is True
+    assert hook.store_results is True
+
+
+def test_hook_run_checks_is_callable() -> None:
+    hook = ProveroHook(config_path="nonexistent.yaml")
+    assert callable(hook.run_checks)
+    assert callable(hook.check_passed)

--- a/provero-airflow/tests/test_operator.py
+++ b/provero-airflow/tests/test_operator.py
@@ -1,0 +1,44 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Smoke tests for ProveroCheckOperator construction and metadata."""
+
+from __future__ import annotations
+
+from provero.airflow.operators import ProveroCheckOperator
+
+
+def test_operator_constructs_with_defaults() -> None:
+    op = ProveroCheckOperator(task_id="check")
+    assert op.config_path == "provero.yaml"
+    assert op.suite is None
+    assert op.fail_on_error is True
+    assert op.optimize is True
+
+
+def test_operator_custom_params() -> None:
+    op = ProveroCheckOperator(
+        task_id="check_orders",
+        config_path="dags/provero.yaml",
+        suite="orders_daily",
+        fail_on_error=False,
+        optimize=False,
+    )
+    assert op.config_path == "dags/provero.yaml"
+    assert op.suite == "orders_daily"
+    assert op.fail_on_error is False
+    assert op.optimize is False
+
+
+def test_operator_template_fields() -> None:
+    assert ProveroCheckOperator.template_fields == ("config_path", "suite")

--- a/provero-airflow/tests/test_provider_info.py
+++ b/provero-airflow/tests/test_provider_info.py
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Smoke tests for Airflow provider metadata."""
+
+from __future__ import annotations
+
+from provero.airflow import get_provider_info
+
+
+def test_provider_info_loads() -> None:
+    info = get_provider_info()
+    assert info["package-name"] == "provero-airflow"
+    assert info["name"] == "Provero"
+
+
+def test_provider_info_declares_components() -> None:
+    info = get_provider_info()
+    assert "hooks" in info
+    assert "operators" in info
+    assert "sensors" in info
+
+    hook_modules = {m for h in info["hooks"] for m in h["python-modules"]}
+    operator_modules = {m for o in info["operators"] for m in o["python-modules"]}
+    sensor_modules = {m for s in info["sensors"] for m in s["python-modules"]}
+
+    assert "provero.airflow.hooks" in hook_modules
+    assert "provero.airflow.operators" in operator_modules
+    assert "provero.airflow.sensors" in sensor_modules

--- a/provero-airflow/tests/test_sensor.py
+++ b/provero-airflow/tests/test_sensor.py
@@ -11,31 +11,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
----
-package-name: provero-airflow
-name: Provero
-description: |
-  Data quality checks for Apache Airflow using Provero.
+"""Smoke tests for ProveroSensor construction."""
 
-  `Provero <https://github.com/provero-org/provero>`__
+from __future__ import annotations
 
-versions:
-  - 0.1.0-dev
+from provero.airflow.sensors import ProveroSensor
 
-dependencies:
-  - apache-airflow>=2.9
 
-hooks:
-  - integration-name: Provero
-    python-modules:
-      - provero.airflow.hooks
+def test_sensor_constructs_with_defaults() -> None:
+    sensor = ProveroSensor(task_id="wait_for_quality")
+    assert sensor.config_path == "provero.yaml"
+    assert sensor.suite is None
+    assert sensor.optimize is True
+    assert sensor.store_results is True
 
-operators:
-  - integration-name: Provero
-    python-modules:
-      - provero.airflow.operators
 
-sensors:
-  - integration-name: Provero
-    python-modules:
-      - provero.airflow.sensors
+def test_sensor_template_fields() -> None:
+    assert ProveroSensor.template_fields == ("config_path", "suite")

--- a/provero-core/src/provero/__init__.py
+++ b/provero-core/src/provero/__init__.py
@@ -17,6 +17,10 @@
 
 """Provero - A vendor-neutral, declarative data quality engine."""
 
+import pkgutil
+
+__path__ = pkgutil.extend_path(__path__, __name__)
+
 try:
     from importlib.metadata import version
 


### PR DESCRIPTION
## Summary
- `ProveroPipelineHook` — connection-based configuration of Provero suites
- `ProveroSensor` — poke-mode quality gating for downstream Airflow tasks
- Refresh `ProveroCheckOperator` + decorators alongside the new symbols
- `provider.yaml` registers the new hook + sensor classes
- Integration tests: hook, sensor, operator, decorator, provider info

## Namespace fix
- Add `pkgutil.extend_path` in `provero-core/src/provero/__init__.py` so `provero.airflow` / `provero.flyte` resolve when both packages are on sys.path. Without this, the regular `provero-core` package shadows sibling subpackages.

## Test plan
- [x] All 12 airflow tests pass
- [x] All 497 core tests still pass